### PR TITLE
Fix: Correct SyntaxError in python_highlighter.py docstring (again)

### DIFF
--- a/python_highlighter.py
+++ b/python_highlighter.py
@@ -147,7 +147,7 @@ class PythonHighlighter(QSyntaxHighlighter):
         Args:
             text (str): The current block's text.
             start_expression (QRegularExpression): Regex for the start delimiter (e.g., triple-double-quotes)
-            end_expression (QRegularExpression): Regex for the end delimiter (e.g., """).
+            end_expression (QRegularExpression): Regex for the end delimiter (e.g., triple-double-quotes).
             target_state (int): The block state to set if this multi-line string continues to the next block.
             fmt (QTextCharFormat): The format to apply to the multi-line string.
 


### PR DESCRIPTION
This commit addresses a persistent SyntaxError (unmatched ')') in `python_highlighter.py`. The error was due to sequences of three consecutive double-quote characters within parenthetical examples in the docstring for the `process_multiline_string` method. These sequences prematurely terminated the docstring, leading to a parsing error.

The previous fix attempt corrected one instance of this error. This commit corrects a second instance on the line describing the `end_expression` parameter.

Both problematic examples, for `start_expression` and `end_expression`, have now been changed from using literal triple-double-quotes to using the phrase "triple-double-quotes" to resolve the error.