### PR TITLE
feat: Implement turn-based collaborative editing

### DIFF
--- a/code_editor.py
+++ b/code_editor.py
@@ -33,6 +33,8 @@ class CodeEditor(QPlainTextEdit):
     A QPlainTextEdit subclass with features like auto-pairing,
     real-time linting, and code completion.
     """
+    control_reclaim_requested = Signal()
+
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -64,6 +66,15 @@ class CodeEditor(QPlainTextEdit):
         self.textChanged.connect(self._on_text_changed_for_completion)
 
     def keyPressEvent(self, event: QKeyEvent):
+        # --- Control Reclaim Logic ---
+        if self.isReadOnly(): # The host is currently a viewer
+            # This event signals the host wants to type again.
+            # Instead of processing the key, emit a custom signal.
+            self.control_reclaim_requested.emit()
+            event.accept() # Indicate the event has been handled
+            return # Absorb the key press for now
+
+        # --- Existing Logic ---
         key_text = event.text()
         cursor = self.textCursor()
 


### PR DESCRIPTION
This commit introduces a structured, turn-based editing model for the collaborative editor, replacing the simple mirroring system.

Key features:
- Editing Token: A logical token governs who can edit. Only one user (Active Editor) can hold the token and write at any time. The other user is a Viewer with a read-only editor. The Host starts with the token.
- Control Flow:
    - Clients can request editing control from the Host.
    - The Host can grant control to a requesting Client, making their own editor read-only.
    - The Host can reclaim control at any time by starting to type in their (read-only) editor. This automatically revokes control from the Client.
- UI Changes:
    - Client UI includes a "Request Control" button, enabled/disabled based on control state.
    - The status bar in `MainWindow` clearly displays the current role (Host/Client) and editing status (Active Editor/Viewer), along with contextual instructions.
    - `CodeEditor` instances are made read-only or writable based on your current control status.
- Networking Protocol:
    - Enhanced to use JSON-based messages.
    - New message types: `REQ_CONTROL`, `GRANT_CONTROL`, `REVOKE_CONTROL`, in addition to the existing `TEXT_UPDATE`.
    - `NetworkManager` updated to send/parse these messages and emit dedicated signals for control actions.
- State Management:
    - `MainWindow` now manages `is_host`, `has_control`, and `session_active` states.
    - A new method `_update_ui_for_control_state` centralizes UI updates based on these states.
- Smart Text Syncing:
    - `TEXT_UPDATE` messages are now only sent by the user who currently `has_control`.
    - Received `TEXT_UPDATE` messages are only applied if the recipient does not have control (i.e., is a viewer), preventing active editors from having their text overwritten.

The changes span `main_window.py` (UI, core logic), `code_editor.py` (host reclaim via `keyPressEvent`), and `network_manager.py` (protocol and message handling).