### PR TITLE
fix: Resolve NameError in CodeEditor linting highlights

### DIFF
--- a/code_editor.py
+++ b/code_editor.py
@@ -145,11 +145,7 @@ class CodeEditor(QPlainTextEdit):
 
     def _update_linting_highlights(self):
         extra_selections = []
-        if hasattr(self, 'ExtraSelection'): # Check if QPlainTextEdit.ExtraSelection is accessible
-            SelectionClass = self.ExtraSelection # For QPlainTextEdit
-        else: # Fallback for QTextEdit or other contexts if needed (though QPlainTextEdit is specified)
-            SelectionClass = QTextEdit.ExtraSelection 
-
+        SelectionClass = self.ExtraSelection # QPlainTextEdit.ExtraSelection
 
         for error in self.linting_errors:
             selection = SelectionClass()


### PR DESCRIPTION
Corrects a NameError in `code_editor.py` that occurred during linting. The `_update_linting_highlights` method incorrectly attempted to fall back to `QTextEdit.ExtraSelection` without `QTextEdit` being imported.

The fix ensures that `SelectionClass` is assigned using `self.ExtraSelection`, which correctly refers to `QPlainTextEdit.ExtraSelection` as `CodeEditor` is a subclass of `QPlainTextEdit`. This removes the erroneous reference and the need for `QTextEdit` in this context.