### PR TITLE
feat: Implement host-approved turn-based editing

### DIFF
--- a/code_editor.py
+++ b/code_editor.py
@@ -33,7 +33,7 @@ class CodeEditor(QPlainTextEdit):
     A QPlainTextEdit subclass with features like auto-pairing,
     real-time linting, and code completion.
     """
-    control_reclaim_requested = Signal()
+    host_wants_to_reclaim_control = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -70,7 +70,7 @@ class CodeEditor(QPlainTextEdit):
         if self.isReadOnly(): # The host is currently a viewer
             # This event signals the host wants to type again.
             # Instead of processing the key, emit a custom signal.
-            self.control_reclaim_requested.emit()
+            self.host_wants_to_reclaim_control.emit()
             event.accept() # Indicate the event has been handled
             return # Absorb the key press for now
 

--- a/network_manager.py
+++ b/network_manager.py
@@ -15,6 +15,7 @@ class NetworkManager(QObject):
     MSG_TYPE_REQ_CONTROL = "REQ_CONTROL"
     MSG_TYPE_GRANT_CONTROL = "GRANT_CONTROL"
     MSG_TYPE_REVOKE_CONTROL = "REVOKE_CONTROL"
+    MSG_TYPE_DECLINE_CONTROL = "DECLINE_CONTROL"
 
     """
     Manages network communication (both server and client roles)
@@ -51,6 +52,7 @@ class NetworkManager(QObject):
     control_request_received = Signal() # Emitted by host when client requests control
     control_granted_received = Signal() # Emitted by client when host grants control
     control_revoked_received = Signal() # Emitted by client when host revokes control
+    control_declined_received = Signal() # Emitted by host when client declines control (or host if client declines)
 
 
     def __init__(self, parent=None):
@@ -251,6 +253,8 @@ class NetworkManager(QObject):
                         self.control_granted_received.emit()
                     elif message_type == self.MSG_TYPE_REVOKE_CONTROL:
                         self.control_revoked_received.emit()
+                    elif message_type == self.MSG_TYPE_DECLINE_CONTROL:
+                        self.control_declined_received.emit()
                     else:
                         print(f"NetworkManager: Unknown message type received: {message_type}")
 


### PR DESCRIPTION
This commit refines the turn-based collaborative editing model to require explicit host approval for control requests from clients.

Key changes:
- Host Approval Dialog: When a client requests editing control, the host is now presented with a QMessageBox dialog to "Accept" or "Decline" the request. Control is only transferred if the host accepts.
- Decline Mechanism:
    - New network message `DECLINE_CONTROL` (Host -> Client) is sent if the host declines the request.
    - Client receives a status bar notification when their request is declined and the "Request Control" button is re-enabled.
- Signal Renaming: The `CodeEditor` signal for host reclaim has been renamed from `control_reclaim_requested` to `host_wants_to_reclaim_control` for clarity. MainWindow has been updated to use this new signal name.
- Network Protocol:
    - Added `MSG_TYPE_DECLINE_CONTROL`.
    - `NetworkManager` updated to handle this new message type and emit a `control_declined_received` signal.
- MainWindow Logic:
    - `_handle_control_request_received` (Host) now manages the approval dialog.
    - New slot `_handle_control_declined_received` (Client) handles the declined state.
    - Signal connections and handler methods updated for the renamed `CodeEditor` signal.

This enhancement provides the host with more explicit control over the editing session, ensuring they must approve any transfer of editing privileges to a client. The host's ability to instantly reclaim control by typing remains.