### PR TITLE
Implement "Join Session" from Welcome Page

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,48 @@
 import sys
 from PySide6.QtWidgets import QApplication
+from welcome_page import WelcomePage
 from main_window import MainWindow
+# AppController and __main__ block follow
+
+class AppController:
+    def __init__(self, app):
+        self.app = app
+        self.main_window = None  # Initialize as None, create when needed
+        self.welcome_screen = WelcomePage()
+
+        # Connect signals from WelcomePage
+        self.welcome_screen.join_session_requested.connect(self.launch_for_join_session)
+        self.welcome_screen.open_file_requested.connect(self.launch_main_window_with_path) # Connect to a generic path handler
+        self.welcome_screen.open_folder_requested.connect(self.launch_main_window_with_path) # Connect to a generic path handler
+
+
+    def start(self):
+        self.welcome_screen.show()
+
+    def _ensure_main_window(self):
+        if self.main_window is None:
+            self.main_window = MainWindow() # Create MainWindow instance
+
+    def launch_for_join_session(self):
+        print("AppController: launch_for_join_session triggered")
+        self._ensure_main_window()
+        self.main_window.join_session_from_welcome_page() # Method created in MainWindow (Step 3)
+        self.main_window.show()
+        self.welcome_screen.close()
+        print("AppController: Join Session - MainWindow configured and shown, WelcomeScreen closed.")
+
+
+    def launch_main_window_with_path(self, path):
+        print(f"AppController: launch_main_window_with_path triggered with path: {path}")
+        self._ensure_main_window()
+        self.main_window.initialize_project(path) # Method created in MainWindow (Step 3)
+        self.main_window.show()
+        self.welcome_screen.close()
+        print(f"AppController: Path '{path}' - MainWindow initialized and shown, WelcomeScreen closed.")
+
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
-    window = MainWindow()
-    window.show()
+    controller = AppController(app)
+    controller.start()
     sys.exit(app.exec())

--- a/main_window.py
+++ b/main_window.py
@@ -59,6 +59,34 @@ class MainWindow(QMainWindow):
         self.update_ui_for_control_state() # Initial UI update
         self.load_session() # Load session on startup
 
+    def initialize_project(self, path: str):
+        if path is None:
+            # This is a client-only startup.
+            # Open a single, empty "Untitled" tab.
+            self.open_new_tab() # Call with no arguments for an empty tab
+            # Hide the file explorer as there is no project context.
+            if hasattr(self, 'file_explorer_dock'): # Check if dock exists
+                self.file_explorer_dock.setVisible(False)
+            print("MainWindow: Initialized for client-only mode (no project path).")
+            return # Stop further processing
+
+        # Placeholder for actual project/file/folder initialization
+        print(f"MainWindow: initialize_project called with path: {path}")
+        if os.path.isfile(path):
+            self.open_new_tab(file_path=path)
+        elif os.path.isdir(path):
+            if hasattr(self, 'file_explorer'):
+                self.file_explorer.set_root_path(path)
+                if hasattr(self, 'file_explorer_dock'):
+                    self.file_explorer_dock.setVisible(True) # Ensure it's visible for folder opening
+            # Potentially open a default file or just show the explorer
+        else:
+            print(f"MainWindow: Path is not a file or directory: {path}")
+            # Fallback to client-only like state if path is invalid
+            self.open_new_tab()
+            if hasattr(self, 'file_explorer_dock'):
+                self.file_explorer_dock.setVisible(False)
+
     def setup_ui(self):
         # Central Editor View (QTabWidget)
         self.tab_widget = QTabWidget()
@@ -389,6 +417,12 @@ class MainWindow(QMainWindow):
                 print(f"LOG: start_hosting_session - is_host={self.is_host}, has_control={self.has_control}")
             else:
                 QMessageBox.critical(self, "Error", "Failed to start hosting session.")
+
+    @Slot()
+    def join_session_from_welcome_page(self):
+        print("MainWindow: join_session_from_welcome_page called.")
+        self.connect_to_host_session()  # This method already exists
+        self.initialize_project(None)   # Setup for client-only mode
 
     @Slot()
     def connect_to_host_session(self):

--- a/welcome_page.py
+++ b/welcome_page.py
@@ -1,0 +1,46 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QPushButton, QLabel, QFileDialog
+from PySide6.QtCore import Signal
+
+class WelcomePage(QWidget):
+    """
+    Welcome Page for the Aether Editor.
+    Allows users to open files, folders, or join a collaborative session.
+    """
+    join_session_requested = Signal()
+    open_file_requested = Signal(str)  # Signal to emit file path
+    open_folder_requested = Signal(str) # Signal to emit folder path
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Welcome")
+        layout = QVBoxLayout(self)
+
+        title = QLabel("Welcome to Aether Editor")
+        title.setStyleSheet("font-size: 18pt; font-weight: bold;") # Basic styling
+        layout.addWidget(title)
+
+        self.open_file_button = QPushButton("Open File...")
+        self.open_file_button.clicked.connect(self._on_open_file)
+        layout.addWidget(self.open_file_button)
+
+        self.open_folder_button = QPushButton("Open Folder...")
+        self.open_folder_button.clicked.connect(self._on_open_folder)
+        layout.addWidget(self.open_folder_button)
+
+        self.join_session_button = QPushButton("Join Session...")
+        self.join_session_button.clicked.connect(self.join_session_requested.emit)
+        layout.addWidget(self.join_session_button)
+
+        self.setFixedSize(400, 300) # Give it a reasonable default size
+
+    def _on_open_file(self):
+        # Use QFileDialog to get a file path
+        file_path, _ = QFileDialog.getOpenFileName(self, "Open File")
+        if file_path:
+            self.open_file_requested.emit(file_path)
+
+    def _on_open_folder(self):
+        # Use QFileDialog to get a directory path
+        folder_path = QFileDialog.getExistingDirectory(self, "Open Folder")
+        if folder_path:
+            self.open_folder_requested.emit(folder_path)


### PR DESCRIPTION
This commit introduces the ability for you to join a collaborative session directly from the Welcome Page without first opening a local project.

The implementation is divided into three main parts:

1.  **WelcomePage (`welcome_page.py` and `main.py`):**
    *   A `WelcomePage` class is introduced in `welcome_page.py`, providing UI
      buttons for "Open File...", "Open Folder...", and "Join Session...".
    *   A `join_session_requested` signal is emitted when the new button is
      clicked.
    *   `main.py` is refactored to use an `AppController` that manages the
      display of the `WelcomePage` and subsequent `MainWindow` launch.

2.  **MainWindow Refactor (`main_window.py`):**
    *   A new method `initialize_project(path)` is added. If `path` is `None`
      (for client-only startup), it opens a single empty "Untitled" tab and
      hides the file explorer. Otherwise, it handles opening the specified
      file or folder.
    *   A new public slot `join_session_from_welcome_page()` is created. This
      method calls the existing `connect_to_host_session()` and then
      `initialize_project(None)` to set up the UI for a client joining a
      session.

3.  **AppController Wiring (`main.py`):**
    *   The `AppController` connects the `WelcomePage.join_session_requested`
      signal to its `launch_for_join_session` method.
    *   `launch_for_join_session` calls `main_window.join_session_from_welcome_page()`,
      shows the main window, and closes the welcome screen, providing a
      distinct startup path for joining a session.
    *   Similar logic handles opening files/folders via `initialize_project(path)`.